### PR TITLE
Convert to white stars

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,5 +7,5 @@ output:
   field_of_view: 180          # deg
   paper_size: [ 210, 240 ]    # mm
 
-datetime: 2020-08-15 12:00:00 +10
+datetime: 2020-10-24 12:00:00 +10
 coordinates: '27.0 S, 153.0 E'

--- a/main.py
+++ b/main.py
@@ -11,8 +11,8 @@ import yaml
 
 from util import stereographicProjection
 
-UQS_BLUE = '#091544'
-SCALE    = 1000
+UQ_PURPLE = '#51247A'
+SCALE     = 1000
 
 
 # Load timescale and ephemeris from JPL
@@ -95,9 +95,10 @@ dwg = svg.Drawing(filename='starcover.svg', size=('300mm', '300mm'))
 dwg.viewbox(minx=-1000, miny=-1000, width=2000, height=2000)
 
 star_group = dwg.g(
-    fill=UQS_BLUE,
+    fill='#FFFFFF',
     fill_opacity=1,
-    stroke='none'
+    stroke=UQ_PURPLE,
+    stroke_width=0.25
 )
 
 for center, marker in zip(star_centers[bright], star_markers[bright]):
@@ -107,7 +108,7 @@ for center, marker in zip(star_centers[bright], star_markers[bright]):
     ))
 
 constellation_group = dwg.g(
-    stroke=UQS_BLUE,
+    stroke='#FFFFFF',
     stroke_width=0.25,
     stroke_opacity=0.25,
     fill='none'


### PR DESCRIPTION
UQ Space has recently undergone a branding change, and thus requires all previous navy items to be updated. 

The proposed new star-cover produces **white** stars, with the **UQ Purple** as an outline to stars. 
Constellations are purely white.